### PR TITLE
cli: Modify dropuser format. Support db_name contains special charact…

### DIFF
--- a/src/cli/callx/callx.go
+++ b/src/cli/callx/callx.go
@@ -688,7 +688,7 @@ func CreateSuperUserRPC(node string, user string, passwd string) (*model.MysqlUs
 	return rsp, err
 }
 
-func DropUserRPC(node string, user string) (*model.MysqlUserRPCResponse, error) {
+func DropUserRPC(node string, user string, host string) (*model.MysqlUserRPCResponse, error) {
 	cli, cleanup, err := GetClient(node)
 	if err != nil {
 		return nil, err
@@ -698,6 +698,7 @@ func DropUserRPC(node string, user string) (*model.MysqlUserRPCResponse, error) 
 	method := model.RPCMysqlDropUser
 	req := model.NewMysqlUserRPCRequest()
 	req.User = user
+	req.Host = host
 
 	rsp := model.NewMysqlUserRPCResponse(model.OK)
 	err = cli.Call(method, req, rsp)
@@ -712,8 +713,10 @@ func CreateUserWithPrivRPC(node, user, passwd, database, table, host, privs stri
 	}
 	defer cleanup()
 
-	if database == "" {
+	if database == "" || database == "*" {
 		database = "*"
+	} else {
+		database = fmt.Sprintf("`%s`", database)
 	}
 	if table == "" {
 		table = "*"

--- a/src/cli/cmd/init_test.go
+++ b/src/cli/cmd/init_test.go
@@ -20,7 +20,6 @@ func TestCLIInitCommand(t *testing.T) {
 	err := createConfig()
 	ErrorOK(err)
 	defer removeConfig()
-
 	ip, err := common.GetLocalIP()
 	assert.Nil(t, err)
 

--- a/src/cli/cmd/mysql.go
+++ b/src/cli/cmd/mysql.go
@@ -526,7 +526,7 @@ func mysqlCreateSuperUserCommandFn(cmd *cobra.Command, args []string) {
 // drop user(normal&super)
 func NewMysqlDropUserCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "dropuser <user>",
+		Use:   "dropuser <user> <host>",
 		Short: "drop mysql normal user",
 		Run:   mysqlDropUserCommandFn,
 	}
@@ -535,12 +535,13 @@ func NewMysqlDropUserCommand() *cobra.Command {
 }
 
 func mysqlDropUserCommandFn(cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
-		ErrorOK(fmt.Errorf("args.count.error:should.be.1"))
+	if len(args) != 2 {
+		ErrorOK(fmt.Errorf("args.count.error:should.be.2"))
 	}
 
 	user := args[0]
-	log.Warning("prepare.to.drop.normaluser[%v]", user)
+	host := args[1]
+	log.Warning("prepare.to.drop.normaluser[%v]@[%v]", user, host)
 	conf, err := GetConfig()
 	ErrorOK(err)
 
@@ -548,11 +549,11 @@ func mysqlDropUserCommandFn(cmd *cobra.Command, args []string) {
 	{
 		leader, err := callx.GetClusterLeader(self)
 		ErrorOK(err)
-		rsp, err := callx.DropUserRPC(leader, user)
+		rsp, err := callx.DropUserRPC(leader, user, host)
 		ErrorOK(err)
 		RspOK(rsp.RetCode)
 	}
-	log.Warning("drop.normaluser[%v].done", user)
+	log.Warning("drop.normaluser[%v]@[%v].done", user, host)
 }
 
 // change normal user password

--- a/src/cli/cmd/mysql_test.go
+++ b/src/cli/cmd/mysql_test.go
@@ -78,10 +78,10 @@ func TestCLIMysqlCommand(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	// drop
+	// drop normal user.
 	{
 		cmd := NewMysqlCommand()
-		_, err := executeCommand(cmd, "dropuser", "userxx")
+		_, err := executeCommand(cmd, "dropuser", "userxx", "%")
 		assert.Nil(t, err)
 	}
 

--- a/src/mysql/api.go
+++ b/src/mysql/api.go
@@ -374,12 +374,12 @@ func (m *Mysql) CreateUser(user string, passwd string) error {
 }
 
 // DropUser used to drop a user.
-func (m *Mysql) DropUser(user string) error {
+func (m *Mysql) DropUser(user string, host string) error {
 	db, err := m.getDB()
 	if err != nil {
 		return err
 	}
-	return m.userHandler.DropUser(db, user)
+	return m.userHandler.DropUser(db, user, host)
 }
 
 // ChangeUserPasswd used to change the user's password.

--- a/src/mysql/mock.go
+++ b/src/mysql/mock.go
@@ -593,7 +593,7 @@ func (u *MockUserA) CreateUserWithPrivileges(db *sql.DB, user, passwd, database,
 }
 
 // DropUser mock.
-func (u *MockUserA) DropUser(db *sql.DB, user string) error {
+func (u *MockUserA) DropUser(db *sql.DB, user string, host string) error {
 	return nil
 }
 

--- a/src/mysql/user.go
+++ b/src/mysql/user.go
@@ -81,8 +81,8 @@ func (u *User) CreateUser(db *sql.DB, user string, passwd string) error {
 }
 
 // DropUser used to drop the user.
-func (u *User) DropUser(db *sql.DB, user string) error {
-	query := fmt.Sprintf("DROP USER `%s`", user)
+func (u *User) DropUser(db *sql.DB, user string, host string) error {
+	query := fmt.Sprintf("DROP USER `%s`@'%s'", user, host)
 	return Execute(db, query)
 }
 

--- a/src/mysql/user_handler.go
+++ b/src/mysql/user_handler.go
@@ -18,7 +18,7 @@ type UserHandler interface {
 	GetUser(*sql.DB) ([]model.MysqlUser, error)
 	CheckUserExists(*sql.DB, string) (bool, error)
 	CreateUser(*sql.DB, string, string) error
-	DropUser(*sql.DB, string) error
+	DropUser(*sql.DB, string, string) error
 	ChangeUserPasswd(*sql.DB, string, string) error
 	CreateReplUserWithoutBinlog(*sql.DB, string, string) error
 	GrantAllPrivileges(*sql.DB, string) error

--- a/src/mysql/user_test.go
+++ b/src/mysql/user_test.go
@@ -71,7 +71,12 @@ func TestCreateUserWithPrivileges(t *testing.T) {
 	mysql := NewMysql(conf, log)
 	mysql.db = db
 
-	query := "GRANT ALTER , ALTER ROUTINE ON test.* TO `xx`@'%' IDENTIFIED BY 'pwd'"
+	query := "GRANT ALTER , ALTER ROUTINE ON test.* TO `xx`@'127.0.0.1' IDENTIFIED BY 'pwd'"
+	mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(1, 1))
+	err = mysql.CreateUserWithPrivileges("xx", "pwd", "test", "*", "127.0.0.1", "ALTER , ALTER ROUTINE")
+	assert.Nil(t, err)
+
+	query = "GRANT ALTER , ALTER ROUTINE ON test.* TO `xx`@'%' IDENTIFIED BY 'pwd'"
 	mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(1, 1))
 	err = mysql.CreateUserWithPrivileges("xx", "pwd", "test", "*", "%", "ALTER , ALTER ROUTINE")
 	assert.Nil(t, err)
@@ -117,9 +122,9 @@ func TestDropUser(t *testing.T) {
 	mysql := NewMysql(conf, log)
 	mysql.db = db
 
-	query := "DROP USER `xx`"
+	query := "DROP USER `xx`@'127.0.0.1'"
 	mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(1, 1))
-	err = mysql.DropUser("xx")
+	err = mysql.DropUser("xx", "127.0.0.1")
 	assert.Nil(t, err)
 }
 

--- a/src/server/rpc_user.go
+++ b/src/server/rpc_user.go
@@ -149,9 +149,9 @@ func (u *UserRPC) DropUser(req *model.MysqlUserRPCRequest, rsp *model.MysqlUserR
 	}
 
 	// drop
-	if err := u.server.mysql.DropUser(req.User); err != nil {
+	if err := u.server.mysql.DropUser(req.User, req.Host); err != nil {
 		rsp.RetCode = err.Error()
-		log.Error("[%v].drop.user.[%v].error[%v]", state.String(), req.User, err)
+		log.Error("[%v].drop.user.[%v]@[%v].error[%v]", state.String(), req.User, req.Host, err)
 		return nil
 	}
 	return nil


### PR DESCRIPTION
…ers.

xenon supports drop 'user'@'host' and supports for databases with special characters

The format of the xenoncli delete user is:

xenoncli mysql dropuser <user> <host>