### PR TITLE
raft: enhancing cluster election

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -48,6 +48,9 @@ type RaftConfig struct {
 	// leader heartbeat interval(ms)
 	HeartbeatTimeout int `json:"heartbeat-timeout"`
 
+	// admit defeat count for hearbeat
+	AdmitDefeatHtCnt int `json:"admit-defeat-hearbeat-count"`
+
 	// election timeout(ms)
 	ElectionTimeout int `json:"election-timeout"`
 
@@ -76,6 +79,7 @@ func DefaultRaftConfig() *RaftConfig {
 	return &RaftConfig{
 		MetaDatadir:         ".",
 		HeartbeatTimeout:    1000,
+		AdmitDefeatHtCnt:    10,
 		ElectionTimeout:     3000,
 		PurgeBinlogInterval: 1000 * 60 * 5,
 		LeaderStartCommand:  "nop",
@@ -117,6 +121,9 @@ type MysqlConfig struct {
 	// ping mysql interval(ms)
 	PingTimeout int `json:"ping-timeout"`
 
+	// admit defeat count for ping mysql
+	AdmitDefeatPingCnt int `json:"admit-defeat-ping-count"`
+
 	// master system variables configure(separated by ;)
 	MasterSysVars string `json:"master-sysvars"`
 
@@ -135,16 +142,17 @@ type MysqlConfig struct {
 
 func DefaultMysqlConfig() *MysqlConfig {
 	return &MysqlConfig{
-		Admin:        "root",
-		Passwd:       "",
-		Host:         "localhost",
-		Port:         3306,
-		PingTimeout:  1000,
-		Basedir:      "/u01/mysql_20160606/",
-		DefaultsFile: "/etc/my3306.cnf",
-		ReplHost:     "127.0.0.1",
-		ReplUser:     "repl",
-		ReplPasswd:   "repl",
+		Admin:              "root",
+		Passwd:             "",
+		Host:               "localhost",
+		Port:               3306,
+		PingTimeout:        1000,
+		AdmitDefeatPingCnt: 2,
+		Basedir:            "/u01/mysql_20160606/",
+		DefaultsFile:       "/etc/my3306.cnf",
+		ReplHost:           "127.0.0.1",
+		ReplUser:           "repl",
+		ReplPasswd:         "repl",
 	}
 }
 

--- a/src/mysql/mysql.go
+++ b/src/mysql/mysql.go
@@ -39,10 +39,6 @@ const (
 	MysqlReadwrite Option = "READWRITE"
 )
 
-var (
-	downsLimits = 2
-)
-
 // PingEntry tuple.
 type PingEntry struct {
 	Relay_Master_Log_File string
@@ -94,6 +90,8 @@ func (m *Mysql) Ping() {
 	var db *sql.DB
 	var pe *PingEntry
 	log := m.log
+
+	downsLimits := m.conf.AdmitDefeatPingCnt
 
 	if db, err = m.getDB(); err != nil {
 		log.Error("mysql[%v].ping.getdb.error[%v].downs:%v,downslimits:%v", m.getConnStr(), err, m.downs, downsLimits)

--- a/src/raft/mock.go
+++ b/src/raft/mock.go
@@ -208,7 +208,7 @@ func (r *Raft) mockLeaderProcessRequestVoteRequest(req *model.RaftRPCRequest) *m
 
 // mock leader send heartbeat request
 // nop here, so other followers will start a new leader election
-func (r *Raft) mockLeaderSendHeartbeat(mysqlDownLimits *int, c chan *model.RaftRPCResponse) {
+func (r *Raft) mockLeaderSendHeartbeat(mysqlDown *bool, c chan *model.RaftRPCResponse) {
 	r.DEBUG("mock.send.nop.heartbeat.request")
 }
 


### PR DESCRIPTION
Add parameter 'AdmitDefeatHtCnt' 'AdmitDefeatPingCnt' used for configuration,
and degrade leader to follower immediately when mysqld dead.