### PR TITLE
xenoncli: add '--ssl' option

### DIFF
--- a/src/cli/callx/callx.go
+++ b/src/cli/callx/callx.go
@@ -673,6 +673,7 @@ func CreateNormalUserRPC(node string, user string, passwd string) (*model.MysqlU
 	return rsp, err
 }
 
+
 func CreateSuperUserRPC(node string, user string, passwd string) (*model.MysqlUserRPCResponse, error) {
 	cli, cleanup, err := GetClient(node)
 	if err != nil {
@@ -708,7 +709,7 @@ func DropUserRPC(node string, user string, host string) (*model.MysqlUserRPCResp
 	return rsp, err
 }
 
-func CreateUserWithPrivRPC(node, user, passwd, database, table, host, privs string) (*model.MysqlUserRPCResponse, error) {
+func CreateUserWithPrivRPC(node, user, passwd, database, table, host, privs string, ssl string) (*model.MysqlUserRPCResponse, error) {
 	cli, cleanup, err := GetClient(node)
 	if err != nil {
 		return nil, err
@@ -735,6 +736,7 @@ func CreateUserWithPrivRPC(node, user, passwd, database, table, host, privs stri
 	req.Table = table
 	req.Host = host
 	req.Privileges = privs
+	req.SSL = ssl
 	rsp := model.NewMysqlUserRPCResponse(model.OK)
 	err = cli.Call(method, req, rsp)
 

--- a/src/cli/cmd/mysql.go
+++ b/src/cli/cmd/mysql.go
@@ -700,7 +700,9 @@ var (
 	grantTable    string
 	grantHost     string
 	grantPrivs    string
+	requireSSL    string
 )
+
 
 // create normal user with privileges
 func NewMysqlCreateUserWithPrivilegesCommand() *cobra.Command {
@@ -715,6 +717,7 @@ func NewMysqlCreateUserWithPrivilegesCommand() *cobra.Command {
 	cmd.Flags().StringVar(&grantTable, "table", "", "--table=<table>")
 	cmd.Flags().StringVar(&grantHost, "host", "", "--host=<host>")
 	cmd.Flags().StringVar(&grantPrivs, "privs", "for example:SELECT,CREATE(comma-separated)", "--privs=<privs>")
+	cmd.Flags().StringVar(&requireSSL, "ssl", "NO","--ssl=<YES/NO>")
 
 	return cmd
 }
@@ -728,7 +731,7 @@ func mysqlCreateUserWithPrivilegesCommandFn(cmd *cobra.Command, args []string) {
 	{
 		leader, err := callx.GetClusterLeader(self)
 		ErrorOK(err)
-		rsp, err := callx.CreateUserWithPrivRPC(leader, grantUser, grantPasswd, grantDatabase, grantTable, grantHost, grantPrivs)
+		rsp, err := callx.CreateUserWithPrivRPC(leader, grantUser, grantPasswd, grantDatabase, grantTable, grantHost, grantPrivs, requireSSL)
 		ErrorOK(err)
 		RspOK(rsp.RetCode)
 	}

--- a/src/cli/cmd/mysql_test.go
+++ b/src/cli/cmd/mysql_test.go
@@ -56,7 +56,7 @@ func TestCLIMysqlCommand(t *testing.T) {
 		_, err := executeCommand(cmd, "createuser", "userxx", "passwdxx")
 		assert.Nil(t, err)
 	}
-
+	
 	// create super user.
 	{
 		cmd := NewMysqlCommand()

--- a/src/model/mysql.go
+++ b/src/model/mysql.go
@@ -175,6 +175,9 @@ type MysqlUserRPCRequest struct {
 
 	// the normal privileges(comma delimited, such as "SELECT,CREATE"
 	Privileges string
+
+	// the ssl required
+	SSL string
 }
 
 type MysqlUser struct {

--- a/src/mysql/api.go
+++ b/src/mysql/api.go
@@ -419,12 +419,12 @@ func (m *Mysql) GrantNormalPrivileges(user string) error {
 }
 
 // CreateUserWithPrivileges used to create a new user with grants.
-func (m *Mysql) CreateUserWithPrivileges(user, passwd, database, table, host, privs string) error {
+func (m *Mysql) CreateUserWithPrivileges(user, passwd, database, table, host, privs string, ssl string) error {
 	db, err := m.getDB()
 	if err != nil {
 		return err
 	}
-	return m.userHandler.CreateUserWithPrivileges(db, user, passwd, database, table, host, privs)
+	return m.userHandler.CreateUserWithPrivileges(db, user, passwd, database, table, host, privs, ssl)
 }
 
 // GrantReplicationPrivileges used to grant replication privs.

--- a/src/mysql/mock.go
+++ b/src/mysql/mock.go
@@ -601,7 +601,7 @@ func (u *MockUserA) GetUser(db *sql.DB) ([]model.MysqlUser, error) {
 }
 
 // CreateUserWithPrivileges mock.
-func (u *MockUserA) CreateUserWithPrivileges(db *sql.DB, user, passwd, database, table, host, privs string) error {
+func (u *MockUserA) CreateUserWithPrivileges(db *sql.DB, user, passwd, database, table, host, privs string, ssl string) error {
 	return nil
 }
 

--- a/src/mysql/user_handler.go
+++ b/src/mysql/user_handler.go
@@ -23,6 +23,6 @@ type UserHandler interface {
 	CreateReplUserWithoutBinlog(*sql.DB, string, string) error
 	GrantAllPrivileges(*sql.DB, string) error
 	GrantNormalPrivileges(*sql.DB, string) error
-	CreateUserWithPrivileges(db *sql.DB, user, passwd, database, table, host, privs string) error
+	CreateUserWithPrivileges(db *sql.DB, user, passwd, database, table, host, privs string, ssl string) error
 	GrantReplicationPrivileges(*sql.DB, string) error
 }

--- a/src/mysql/user_test.go
+++ b/src/mysql/user_test.go
@@ -73,14 +73,13 @@ func TestCreateUserWithPrivileges(t *testing.T) {
 
 	query := "GRANT ALTER , ALTER ROUTINE ON test.* TO `xx`@'127.0.0.1' IDENTIFIED BY 'pwd'"
 	mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(1, 1))
-	err = mysql.CreateUserWithPrivileges("xx", "pwd", "test", "*", "127.0.0.1", "ALTER , ALTER ROUTINE")
+	err = mysql.CreateUserWithPrivileges("xx", "pwd", "test", "*", "127.0.0.1", "ALTER , ALTER ROUTINE", "NO")
 	assert.Nil(t, err)
 
-	query = "GRANT ALTER , ALTER ROUTINE ON test.* TO `xx`@'%' IDENTIFIED BY 'pwd'"
+	query = "GRANT ALTER , ALTER ROUTINE ON test.* TO `xx`@'%' IDENTIFIED BY 'pwd' REQUIRE X509"
 	mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(1, 1))
-	err = mysql.CreateUserWithPrivileges("xx", "pwd", "test", "*", "%", "ALTER , ALTER ROUTINE")
+	err = mysql.CreateUserWithPrivileges("xx", "pwd", "test", "*", "%", "ALTER , ALTER ROUTINE", "YES")
 	assert.Nil(t, err)
-
 }
 
 func TestGetUser(t *testing.T) {
@@ -241,9 +240,10 @@ func TestGrantUserPrivileges(t *testing.T) {
 		table := "table1"
 		host := "192.168.0.1"
 		privs := "SELECT"
+		ssl := "NO"
 		query := "GRANT SELECT ON db.table1 TO `xx`@'192.168.0.1' IDENTIFIED BY 'pwd'"
 		mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(1, 1))
-		err = mysql.CreateUserWithPrivileges(user, passwd, database, table, host, privs)
+		err = mysql.CreateUserWithPrivileges(user, passwd, database, table, host, privs, ssl)
 		assert.Nil(t, err)
 	}
 
@@ -255,9 +255,10 @@ func TestGrantUserPrivileges(t *testing.T) {
 		table := "table1"
 		host := "192.168.0.1"
 		privs := "SELECT,"
-		query := "GRANT SELECT ON db.table1 TO `xx`@'192.168.0.1' IDENTIFIED BY 'pwd'"
+		ssl := "YES"
+		query := "GRANT SELECT ON db.table1 TO `xx`@'192.168.0.1' IDENTIFIED BY 'pwd' REQUIRE X509"
 		mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(1, 1))
-		err = mysql.CreateUserWithPrivileges(user, passwd, database, table, host, privs)
+		err = mysql.CreateUserWithPrivileges(user, passwd, database, table, host, privs, ssl)
 		assert.Nil(t, err)
 	}
 
@@ -269,9 +270,10 @@ func TestGrantUserPrivileges(t *testing.T) {
 		table := "table1"
 		host := "192.168.0.1"
 		privs := "SELECT,GRANT OPTION"
-		query := "GRANT SELECT ON db.table1 TO `xx`@'192.168.0.1' IDENTIFIED BY 'pwd'"
+		ssl := "X509"
+		query := "GRANT SELECT ON db.table1 TO `xx`@'192.168.0.1' IDENTIFIED BY 'pwd' REQUIRE X509"
 		mock.ExpectExec(query).WillReturnResult(sqlmock.NewResult(1, 1))
-		err = mysql.CreateUserWithPrivileges(user, passwd, database, table, host, privs)
+		err = mysql.CreateUserWithPrivileges(user, passwd, database, table, host, privs, ssl)
 		want := "cant' create user[xx] with privileges[GRANT OPTION]"
 		got := err.Error()
 		assert.Equal(t, want, got)

--- a/src/server/rpc_user.go
+++ b/src/server/rpc_user.go
@@ -107,7 +107,7 @@ func (u *UserRPC) CreateUserWithPrivileges(req *model.MysqlUserRPCRequest, rsp *
 	}
 
 	// creates
-	if err := u.server.mysql.CreateUserWithPrivileges(req.User, req.Passwd, req.Database, req.Table, req.Host, req.Privileges); err != nil {
+	if err := u.server.mysql.CreateUserWithPrivileges(req.User, req.Passwd, req.Database, req.Table, req.Host, req.Privileges, req.SSL); err != nil {
 		rsp.RetCode = err.Error()
 		log.Error("rpc[%v].create.user[%v].with.priv.error[%v]", state.String(), req.User, err)
 		return nil


### PR DESCRIPTION
cli mysql createuserwithgrant add '--ssl=<NONE/X509>' option.

grant user grammar: grant privs on *.* to 'user'@'%' identified by 'passwd' require $ssl_option;