### PR TITLE
patch: Enhance raft's invalid logic

### DIFF
--- a/src/mysql/mock.go
+++ b/src/mysql/mock.go
@@ -35,6 +35,7 @@ type MockGTID struct {
 	ChangeToMasterFn           func(*sql.DB) error
 	WaitUntilAfterGTIDFn       func(*sql.DB, string) error
 	GetGtidSubtractFn          func(*sql.DB, string, string) (string, error)
+	GetUUIDFn                  func(*sql.DB) (string, error)
 	CheckGTIDFn                func(*model.GTID, *model.GTID) bool
 	SetGlobalSysVarFn          func(*sql.DB, string) error
 	ResetMasterFn              func(*sql.DB) error
@@ -68,6 +69,16 @@ func DefaultGetSlaveGTID(db *sql.DB) (*model.GTID, error) {
 // GetSlaveGTID mock.
 func (mogtid *MockGTID) GetSlaveGTID(db *sql.DB) (*model.GTID, error) {
 	return mogtid.GetSlaveGTIDFn(db)
+}
+
+// DefaultGetUUID mock.
+func DefaultGetUUID(db *sql.DB) (string, error) {
+	return "84030605-66aa-11e6-9465-52540e7fd51c", nil
+}
+
+// GetUUID mock.
+func (mogtid *MockGTID) GetUUID(db *sql.DB) (string, error) {
+	return mogtid.GetUUIDFn(db)
 }
 
 // DefaultGetMasterGTID mock.
@@ -386,6 +397,7 @@ func defaultMockGTID() *MockGTID {
 	mock.ChangeToMasterFn = DefaultChangeToMaster
 	mock.WaitUntilAfterGTIDFn = DefaultWaitUntilAfterGTID
 	mock.GetGtidSubtractFn = DefaultGetGtidSubtract
+	mock.GetUUIDFn = DefaultGetUUID
 	mock.CheckGTIDFn = DefaultCheckGTID
 	mock.SetGlobalSysVarFn = DefaultSetGlobalSysVar
 	mock.ResetMasterFn = DefaultResetMaster
@@ -450,31 +462,21 @@ func GetMasterGTIDA(db *sql.DB) (*model.GTID, error) {
 	return gtid, nil
 }
 
+func GetUUIDA(db *sql.DB) (string, error) {
+	return "052077a5-b6f4-ee1b-61ec-d80a8b27d749", nil
+}
+
 // NewMockGTIDA mock.
 func NewMockGTIDA() *MockGTID {
 	mock := defaultMockGTID()
 	mock.GetMasterGTIDFn = GetMasterGTIDA
 	mock.GetSlaveGTIDFn = GetSlaveGTIDA
+	mock.GetUUIDFn = GetUUIDA
 	return mock
 }
 
-// GetSlaveGTIDLC mock.
-func GetSlaveGTIDLC(db *sql.DB) (*model.GTID, error) {
-	gtid := &model.GTID{}
-	gtid.Master_Log_File = ""
-	gtid.Read_Master_Log_Pos = 0
-	gtid.Slave_IO_Running = true
-	gtid.Slave_SQL_Running = true
-	gtid.Slave_IO_Running_Str = "Yes"
-	gtid.Slave_SQL_Running_Str = "Yes"
-	gtid.Seconds_Behind_Master = "1"
-	gtid.Last_Error = ""
-	gtid.Slave_SQL_Running_State = "Slave has read all relay log; waiting for the slave I/O thread to update it"
-	gtid.Executed_GTID_Set = `052077a5-b6f4-ee1b-61ec-d80a8b27d749:1-37,
-    12446bf7-3219-11e5-9434-080027079e3d:8058-963126`
-	gtid.Retrieved_GTID_Set = `052077a5-b6f4-ee1b-61ec-d80a8b27d749:1-36,
-    12446bf7-3219-11e5-9434-080027079e3d:8058-963126`
-	return gtid, nil
+func GetUUIDLC(db *sql.DB) (string, error) {
+	return "052077a5-b6f4-ee1b-61ec-d80a8b27d749", nil
 }
 
 // GetMasterGTIDLC mock.
@@ -505,6 +507,7 @@ func NewMockGTIDLC() *MockGTID {
 	mock.GetSlaveGTIDFn = GetMasterGTIDLC
 	mock.CheckGTIDFn = CheckGTIDLC
 	mock.GetGtidSubtractFn = GetGtidSubtractInvalid
+	mock.GetUUIDFn = GetUUIDLC
 	return mock
 }
 

--- a/src/mysql/mysql.go
+++ b/src/mysql/mysql.go
@@ -123,6 +123,27 @@ func (m *Mysql) Ping() {
 	m.pingEntry = *pe
 }
 
+// GetUUID used to get local uuid.
+func (m *Mysql) GetUUID() (string, error) {
+	var err error
+	var db *sql.DB
+	var uuid string
+	log := m.log
+
+	if db, err = m.getDB(); err != nil {
+		log.Error("mysql.get.local.uuid.error[%v]", err)
+		return "", err
+	}
+
+	if uuid, err = m.mysqlHandler.GetUUID(db); err != nil {
+		log.Error("mysql.get.local.uuid.error[%v]", err)
+		return "", err
+	}
+	log.Info("mysql.get.local.uuid:[%v]", uuid)
+
+	return uuid, nil
+}
+
 // GetMasterGTID used to get master binlog info.
 func (m *Mysql) GetMasterGTID() (*model.GTID, error) {
 	var err error

--- a/src/mysql/mysql_handler.go
+++ b/src/mysql/mysql_handler.go
@@ -48,6 +48,9 @@ type MysqlHandler interface {
 	// waits until slave replication reaches at least targetGTID
 	WaitUntilAfterGTID(*sql.DB, string) error
 
+	// get local uuid
+	GetUUID(db *sql.DB) (string, error)
+
 	// get gtid subtract with slavegtid and master gtid
 	GetGtidSubtract(*sql.DB, string, string) (string, error)
 

--- a/src/mysql/mysqlbase.go
+++ b/src/mysql/mysqlbase.go
@@ -126,12 +126,27 @@ func (my *MysqlBase) GetMasterGTID(db *sql.DB) (*model.GTID, error) {
 		gtid.Master_Log_File = row["File"]
 		gtid.Read_Master_Log_Pos, _ = strconv.ParseUint(row["Position"], 10, 64)
 		gtid.Executed_GTID_Set = row["Executed_Gtid_Set"]
-		gtid.Retrieved_GTID_Set = row["Executed_Gtid_Set"]
 		gtid.Seconds_Behind_Master = "0"
 		gtid.Slave_IO_Running = true
 		gtid.Slave_SQL_Running = true
 	}
 	return gtid, nil
+}
+
+// GetUUID used to get local uuid.
+func (my *MysqlBase) GetUUID(db *sql.DB) (string, error) {
+	uuid := ""
+	query := "SELECT @@SERVER_UUID"
+	rows, err := QueryWithTimeout(db, reqTimeout, query)
+	if err != nil {
+		return uuid, err
+	}
+	if len(rows) > 0 {
+		row := rows[0]
+		uuid = row["@@SERVER_UUID"]
+	}
+
+	return uuid, nil
 }
 
 // StartSlaveIOThread used to start the io thread.

--- a/src/mysql/mysqlbase_test.go
+++ b/src/mysql/mysqlbase_test.go
@@ -136,7 +136,7 @@ func TestMysqlBaseGetMasterGTID(t *testing.T) {
 
 		want := model.GTID{Master_Log_File: "mysql-bin.000001",
 			Read_Master_Log_Pos:     147,
-			Retrieved_GTID_Set:      "84030605-66aa-11e6-9465-52540e7fd51c:154-160",
+			Retrieved_GTID_Set:      "",
 			Executed_GTID_Set:       "84030605-66aa-11e6-9465-52540e7fd51c:154-160",
 			Slave_IO_Running:        true,
 			Slave_SQL_Running:       true,
@@ -157,6 +157,22 @@ func TestMysqlBaseGetMasterGTID(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, want, *got)
 	}
+}
+
+func TestGetUUID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.Nil(t, err)
+	defer db.Close()
+
+	query := "SELECT @@SERVER_UUID"
+	columns := []string{"@@SERVER_UUID"}
+	mockRows := sqlmock.NewRows(columns).AddRow("84030605-66aa-11e6-9465-52540e7fd51c")
+	mock.ExpectQuery(query).WillReturnRows(mockRows)
+
+	want := "84030605-66aa-11e6-9465-52540e7fd51c"
+
+	got, _ := mysqlbase.GetUUID(db)
+	assert.Equal(t, want, got)
 }
 
 func TestMysqlBaseChangeMasterToCommand(t *testing.T) {

--- a/src/raft/follower.go
+++ b/src/raft/follower.go
@@ -315,11 +315,12 @@ func (r *Follower) startCheckUpgradeToC() {
 					}
 				}
 
-				if cnt >= r.GetQuorums() {
-					r.WARNING("ping.responses[%v].more.than.half.upgrade.to.candidate", cnt)
-					r.fUpgradeToC = true
+				if cnt < r.GetQuorums() {
+					r.fUpgradeToC = false
 					continue
 				}
+				r.WARNING("ping.responses[%v].more.than.half.upgrade.to.candidate", cnt)
+				r.fUpgradeToC = true
 			}
 		}
 	}()
@@ -377,7 +378,6 @@ func (r *Follower) degradeToInvalid(followerGTID *model.GTID, candidateGTID *mod
 		r.setState(INVALID)
 		return
 	}
-	return
 }
 
 // setMySQLAsync used to setting mysql in async

--- a/src/raft/raft_test.go
+++ b/src/raft/raft_test.go
@@ -825,7 +825,6 @@ func TestRaftEpochChangeUnderIDLE(t *testing.T) {
 		// wait epoch change broadcast
 		MockWaitLeaderEggs(rafts, 0)
 
-		whoisleader = 0
 		for _, raft := range rafts {
 			peers := raft.GetPeers()
 			for _, peer := range peers {
@@ -1050,10 +1049,8 @@ func TestRaft11Rafts1Cluster(t *testing.T) {
 		// wait leader eggs
 		MockWaitLeaderEggs(rafts, 1)
 
-		whoisleader = 0
-		for i, raft := range rafts {
+		for _, raft := range rafts {
 			if raft.getState() == LEADER {
-				whoisleader = i
 				break
 			}
 		}
@@ -1732,6 +1729,7 @@ func TestRaftLeaderWaitUntilAfterGTIDError(t *testing.T) {
 		want := (LEADER + FOLLOWER + FOLLOWER)
 		for _, raft := range rafts {
 			got += raft.getState()
+			log.Printf("test.raft.state.[%v]", raft.getState())
 		}
 		assert.True(t, got < want)
 	}


### PR DESCRIPTION
Now, sometimes the invalid state exists false report:

Hypothesis， we have three nodes: LeaderA, FollowerB, FollowerC


Three nodes are zoned to form 1-1-1 distribution. LeaderA degrade to FollowerA 

recover FollowerB's network, it received a insert but does not execute it, And FollowerB upgrade to LeaderB

Now The Leader has been re-elected and FollowerA's Execute_GTID_SET bigger than LeaderB's Execute_GTID_SET.