### PR TITLE
raft: candidate with newer data quickly keep up with newer viewid

### DIFF
--- a/src/raft/candidate.go
+++ b/src/raft/candidate.go
@@ -212,6 +212,11 @@ func (r *Candidate) processRequestVoteRequest(req *model.RaftRPCRequest) *model.
 		rsp.GTID = thisGTID
 
 		if greater {
+			// keep up with the latest viewid to get the latest nodes of data elected faster
+			if req.GetViewID() > r.getViewID() {
+				r.updateView(req.GetViewID(), noLeader)
+			}
+
 			// reject cases:
 			// 1. I am promotable: I am alive and GTID greater than you
 			if r.mysql.Promotable() {


### PR DESCRIPTION
In extreme cases, the situation used to recur within some minutes:
Node1(more data), Node2(bigger viewid), Node3(less data & smaller viewid)
                                                 InvalidViewID
Node1: F --------------> C --------------> F -> ... -> C
                   InvalidGITD
Node2: C --------------> F --------------> C -> ... -> F
The candidate with newer data has no chance to update viewid.