### PR TITLE
patch: increase Leader GetGTID timeout

### DIFF
--- a/src/mysql/api_test.go
+++ b/src/mysql/api_test.go
@@ -397,7 +397,7 @@ func TestGTIDGreaterThan(t *testing.T) {
 
 		mock.ExpectQuery(query).WillReturnRows(mockRows)
 		want := true
-		got, _, err := mysql.GTIDGreaterThan(&GTID)
+		got, _, err := mysql.GTIDGreaterThan(&GTID, nil)
 		assert.Nil(t, err)
 		assert.Equal(t, want, got)
 	}
@@ -431,13 +431,14 @@ func TestGTIDGreaterThan(t *testing.T) {
 
 		mock.ExpectQuery(query).WillReturnRows(mockRows)
 		want := true
-		got, _, err := mysql.GTIDGreaterThan(&GTID)
+		got, _, err := mysql.GTIDGreaterThan(&GTID, nil)
 		assert.Nil(t, err)
 		assert.Equal(t, want, got)
 	}
 
 	// 3. Seconds_Behind_Master error
 	{
+		raftReqVoteCnt := 2
 		query := "SHOW SLAVE STATUS"
 		columns := []string{"Master_Log_File",
 			"Read_Master_Log_Pos",
@@ -465,13 +466,14 @@ func TestGTIDGreaterThan(t *testing.T) {
 
 		mock.ExpectQuery(query).WillReturnRows(mockRows)
 		want := false
-		got, _, err := mysql.GTIDGreaterThan(&GTID)
+		got, _, err := mysql.GTIDGreaterThan(&GTID, &raftReqVoteCnt)
 		assert.Nil(t, err)
 		assert.Equal(t, want, got)
 	}
 
 	// 4. Seconds_Behind_Master error too
 	{
+		raftReqVoteCnt := 1
 		query := "SHOW SLAVE STATUS"
 		columns := []string{"Master_Log_File",
 			"Read_Master_Log_Pos",
@@ -499,7 +501,7 @@ func TestGTIDGreaterThan(t *testing.T) {
 
 		mock.ExpectQuery(query).WillReturnRows(mockRows)
 		want := false
-		got, _, err := mysql.GTIDGreaterThan(&GTID)
+		got, _, err := mysql.GTIDGreaterThan(&GTID, &raftReqVoteCnt)
 		assert.Nil(t, err)
 		assert.Equal(t, want, got)
 	}
@@ -544,7 +546,7 @@ func TestGetGTID(t *testing.T) {
 			"Yes")
 
 		mock.ExpectQuery(query).WillReturnRows(mockRows)
-		got, _ := mysql.GetGTID()
+		got, _ := mysql.GetGTID(0)
 		assert.Equal(t, want, got)
 	}
 
@@ -593,7 +595,7 @@ func TestGetGTID(t *testing.T) {
 			Slave_SQL_Running_State: "",
 		}
 
-		got, _ := mysql.GetGTID()
+		got, _ := mysql.GetGTID(0)
 		assert.Equal(t, want, got)
 	}
 
@@ -621,7 +623,7 @@ func TestGetGTID(t *testing.T) {
 			Slave_SQL_Running_Str: "No",
 		}
 
-		got, _ := mysql.GetGTID()
+		got, _ := mysql.GetGTID(0)
 		assert.Equal(t, want, got)
 	}
 }

--- a/src/mysql/mock.go
+++ b/src/mysql/mock.go
@@ -25,8 +25,8 @@ import (
 type MockGTID struct {
 	PingFn                     func(*sql.DB) (*PingEntry, error)
 	SetReadOnlyFn              func(*sql.DB, bool) error
-	GetMasterGTIDFn            func(*sql.DB) (*model.GTID, error)
-	GetSlaveGTIDFn             func(*sql.DB) (*model.GTID, error)
+	GetMasterGTIDFn            func(*sql.DB, int) (*model.GTID, error)
+	GetSlaveGTIDFn             func(*sql.DB, int) (*model.GTID, error)
 	StartSlaveIOThreadFn       func(*sql.DB) error
 	StopSlaveIOThreadFn        func(*sql.DB) error
 	StartSlaveFn               func(*sql.DB) error
@@ -61,14 +61,14 @@ type MockGTID struct {
 }
 
 // DefaultGetSlaveGTID returns the default slave gtid.
-func DefaultGetSlaveGTID(db *sql.DB) (*model.GTID, error) {
+func DefaultGetSlaveGTID(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	return gtid, nil
 }
 
 // GetSlaveGTID mock.
-func (mogtid *MockGTID) GetSlaveGTID(db *sql.DB) (*model.GTID, error) {
-	return mogtid.GetSlaveGTIDFn(db)
+func (mogtid *MockGTID) GetSlaveGTID(db *sql.DB, incTimeout int) (*model.GTID, error) {
+	return mogtid.GetSlaveGTIDFn(db, incTimeout)
 }
 
 // DefaultGetUUID mock.
@@ -82,14 +82,14 @@ func (mogtid *MockGTID) GetUUID(db *sql.DB) (string, error) {
 }
 
 // DefaultGetMasterGTID mock.
-func DefaultGetMasterGTID(db *sql.DB) (*model.GTID, error) {
+func DefaultGetMasterGTID(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	return gtid, nil
 }
 
 // GetMasterGTID mock.
-func (mogtid *MockGTID) GetMasterGTID(db *sql.DB) (*model.GTID, error) {
-	return mogtid.GetMasterGTIDFn(db)
+func (mogtid *MockGTID) GetMasterGTID(db *sql.DB, incTimeout int) (*model.GTID, error) {
+	return mogtid.GetMasterGTIDFn(db, incTimeout)
 }
 
 // DefaultStartSlaveIOThread mock.
@@ -429,7 +429,7 @@ func defaultMockGTID() *MockGTID {
 // GetSlaveGTIDA mock.
 // with GTID{Master_Log_File = "", Read_Master_Log_Pos = 0}
 // all functions return is OK
-func GetSlaveGTIDA(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDA(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = ""
 	gtid.Read_Master_Log_Pos = 0
@@ -448,7 +448,7 @@ func GetSlaveGTIDA(db *sql.DB) (*model.GTID, error) {
 }
 
 // GetMasterGTIDA mock.
-func GetMasterGTIDA(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDA(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = ""
 	gtid.Read_Master_Log_Pos = 0
@@ -482,7 +482,7 @@ func GetUUIDLC(db *sql.DB) (string, error) {
 }
 
 // GetMasterGTIDLC mock.
-func GetMasterGTIDLC(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDLC(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = ""
 	gtid.Read_Master_Log_Pos = 0
@@ -524,7 +524,7 @@ func NewMockGTIDAA() *MockGTID {
 }
 
 // GetSlaveGTIDB mock.
-func GetSlaveGTIDAA(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDAA(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 
 	gtid.Master_Log_File = "mysql-bin.000001"
@@ -537,7 +537,7 @@ func GetSlaveGTIDAA(db *sql.DB) (*model.GTID, error) {
 }
 
 // GetMasterGTIDB mock.
-func GetMasterGTIDAA(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDAA(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 
 	gtid.Master_Log_File = "mysql-bin.000001"
@@ -560,7 +560,7 @@ func NewMockGTIDB() *MockGTID {
 }
 
 // GetSlaveGTIDB mock.
-func GetSlaveGTIDB(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDB(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 
 	gtid.Master_Log_File = "mysql-bin.000001"
@@ -573,7 +573,7 @@ func GetSlaveGTIDB(db *sql.DB) (*model.GTID, error) {
 }
 
 // GetMasterGTIDB mock.
-func GetMasterGTIDB(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDB(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 
 	gtid.Master_Log_File = "mysql-bin.000001"
@@ -595,7 +595,7 @@ func NewMockGTIDBB() *MockGTID {
 }
 
 // GetSlaveGTIDBB mock.
-func GetSlaveGTIDBB(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDBB(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 
 	gtid.Master_Log_File = "mysql-bin.000001"
@@ -607,7 +607,7 @@ func GetSlaveGTIDBB(db *sql.DB) (*model.GTID, error) {
 }
 
 // GetMasterGTIDBB mock.
-func GetMasterGTIDBB(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDBB(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 
 	gtid.Master_Log_File = "mysql-bin.000001"
@@ -629,7 +629,7 @@ func NewMockGTIDC() *MockGTID {
 }
 
 // GetSlaveGTIDC mock.
-func GetSlaveGTIDC(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDC(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000001"
 	gtid.Read_Master_Log_Pos = 124
@@ -642,7 +642,7 @@ func GetSlaveGTIDC(db *sql.DB) (*model.GTID, error) {
 }
 
 // GetMasterGTIDC mock.
-func GetMasterGTIDC(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDC(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000001"
 	gtid.Read_Master_Log_Pos = 125
@@ -664,7 +664,7 @@ func NewMockGTIDCC() *MockGTID {
 }
 
 // GetSlaveGTIDC mock.
-func GetSlaveGTIDCC(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDCC(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000001"
 	gtid.Read_Master_Log_Pos = 124
@@ -677,7 +677,7 @@ func GetSlaveGTIDCC(db *sql.DB) (*model.GTID, error) {
 }
 
 // GetMasterGTIDC mock.
-func GetMasterGTIDCC(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDCC(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000001"
 	gtid.Read_Master_Log_Pos = 125
@@ -695,7 +695,7 @@ func NewMockGTIDD() *MockGTID {
 }
 
 // GetMasterGTIDD mock.
-func GetMasterGTIDD(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDD(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000001"
 	gtid.Read_Master_Log_Pos = 126
@@ -715,7 +715,7 @@ func NewMockGTIDPingError() *MockGTID {
 }
 
 // GetMasterGTIDPingError mock.
-func GetMasterGTIDPingError(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDPingError(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000001"
 	gtid.Read_Master_Log_Pos = 124
@@ -739,7 +739,7 @@ func NewMockGTIDInvalid() *MockGTID {
 	return mock
 }
 
-func GetMasterGTIDInvalid(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDInvalid(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000001"
 	gtid.Read_Master_Log_Pos = 122
@@ -769,12 +769,12 @@ func NewMockGTIDError() *MockGTID {
 }
 
 // GetSlaveGTIDError mock.
-func GetSlaveGTIDError(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDError(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	return nil, errors.New("mock.GetSlaveGTID.error")
 }
 
 // GetMasterGTIDError mock.
-func GetMasterGTIDError(db *sql.DB) (*model.GTID, error) {
+func GetMasterGTIDError(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	return nil, errors.New("mock.GetMasterGTID.error")
 }
 
@@ -851,7 +851,7 @@ func PingX1(db *sql.DB) (*PingEntry, error) {
 }
 
 // GetSlaveGTIDX1 mock.
-func GetSlaveGTIDX1(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDX1(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000001"
 	gtid.Read_Master_Log_Pos = 123
@@ -881,7 +881,7 @@ func PingX3(db *sql.DB) (*PingEntry, error) {
 }
 
 // GetSlaveGTIDX3 mock.
-func GetSlaveGTIDX3(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDX3(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000003"
 	gtid.Read_Master_Log_Pos = 123
@@ -911,7 +911,7 @@ func PingX5(db *sql.DB) (*PingEntry, error) {
 }
 
 // GetSlaveGTIDX5 mock.
-func GetSlaveGTIDX5(db *sql.DB) (*model.GTID, error) {
+func GetSlaveGTIDX5(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 	gtid.Master_Log_File = "mysql-bin.000005"
 	gtid.Read_Master_Log_Pos = 123

--- a/src/mysql/mysql.go
+++ b/src/mysql/mysql.go
@@ -145,7 +145,7 @@ func (m *Mysql) GetUUID() (string, error) {
 }
 
 // GetMasterGTID used to get master binlog info.
-func (m *Mysql) GetMasterGTID() (*model.GTID, error) {
+func (m *Mysql) GetMasterGTID(incTimeout int) (*model.GTID, error) {
 	var err error
 	var db *sql.DB
 	var gtid *model.GTID
@@ -154,14 +154,14 @@ func (m *Mysql) GetMasterGTID() (*model.GTID, error) {
 		return nil, err
 	}
 
-	if gtid, err = m.mysqlHandler.GetMasterGTID(db); err != nil {
+	if gtid, err = m.mysqlHandler.GetMasterGTID(db, incTimeout); err != nil {
 		return nil, err
 	}
 	return gtid, nil
 }
 
 // GetSlaveGTID used to get Relay_Master_Log_File and read_master_binlog_pos.
-func (m *Mysql) GetSlaveGTID() (*model.GTID, error) {
+func (m *Mysql) GetSlaveGTID(reqTimeout int) (*model.GTID, error) {
 	var err error
 	var db *sql.DB
 	var gtid *model.GTID
@@ -170,7 +170,7 @@ func (m *Mysql) GetSlaveGTID() (*model.GTID, error) {
 		return nil, err
 	}
 
-	if gtid, err = m.mysqlHandler.GetSlaveGTID(db); err != nil {
+	if gtid, err = m.mysqlHandler.GetSlaveGTID(db, reqTimeout); err != nil {
 		return nil, err
 	}
 	return gtid, nil

--- a/src/mysql/mysql_handler.go
+++ b/src/mysql/mysql_handler.go
@@ -22,10 +22,10 @@ type MysqlHandler interface {
 	SetReadOnly(*sql.DB, bool) error
 
 	// get GTID from traversal binlog folder and find the newest one
-	GetMasterGTID(*sql.DB) (*model.GTID, error)
+	GetMasterGTID(*sql.DB, int) (*model.GTID, error)
 
 	// get GTID from SHOW SLAVE STATUS
-	GetSlaveGTID(*sql.DB) (*model.GTID, error)
+	GetSlaveGTID(*sql.DB, int) (*model.GTID, error)
 
 	// start slave io_thread
 	StartSlaveIOThread(*sql.DB) error

--- a/src/mysql/mysqlbase.go
+++ b/src/mysql/mysqlbase.go
@@ -85,11 +85,11 @@ func (my *MysqlBase) SetReadOnly(db *sql.DB, readonly bool) error {
 
 // GetSlaveGTID gets the gtid from the default channel.
 // Here, We just show the default slave channel.
-func (my *MysqlBase) GetSlaveGTID(db *sql.DB) (*model.GTID, error) {
+func (my *MysqlBase) GetSlaveGTID(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 
 	query := "SHOW SLAVE STATUS"
-	rows, err := QueryWithTimeout(db, reqTimeout, query)
+	rows, err := QueryWithTimeout(db, reqTimeout+incTimeout, query)
 	if err != nil {
 		return gtid, err
 	}
@@ -113,11 +113,11 @@ func (my *MysqlBase) GetSlaveGTID(db *sql.DB) (*model.GTID, error) {
 }
 
 // GetMasterGTID used to get binlog info from master.
-func (my *MysqlBase) GetMasterGTID(db *sql.DB) (*model.GTID, error) {
+func (my *MysqlBase) GetMasterGTID(db *sql.DB, incTimeout int) (*model.GTID, error) {
 	gtid := &model.GTID{}
 
 	query := "SHOW MASTER STATUS"
-	rows, err := QueryWithTimeout(db, reqTimeout, query)
+	rows, err := QueryWithTimeout(db, reqTimeout+incTimeout, query)
 	if err != nil {
 		return nil, err
 	}

--- a/src/mysql/mysqlbase_test.go
+++ b/src/mysql/mysqlbase_test.go
@@ -67,7 +67,7 @@ func TestMysqlBaseGetSlaveGTIDGotZeroRow(t *testing.T) {
 	want := model.GTID{}
 	mockRows := sqlmock.NewRows(columns).AddRow("", "", "", "", "", "", "", "", "")
 	mock.ExpectQuery(query).WillReturnRows(mockRows)
-	got, err := mysqlbase.GetSlaveGTID(db)
+	got, err := mysqlbase.GetSlaveGTID(db, 5000)
 	assert.Nil(t, err)
 	assert.Equal(t, want, *got)
 }
@@ -114,7 +114,7 @@ func TestMysqlBaseGetSlaveGTID(t *testing.T) {
 	)
 
 	mock.ExpectQuery(query).WillReturnRows(mockRows)
-	got, err := mysqlbase.GetSlaveGTID(db)
+	got, err := mysqlbase.GetSlaveGTID(db, 5000)
 	assert.Nil(t, err)
 	assert.Equal(t, want, *got)
 }
@@ -153,7 +153,7 @@ func TestMysqlBaseGetMasterGTID(t *testing.T) {
 		)
 
 		mock.ExpectQuery(query).WillReturnRows(mockRows)
-		got, err := mysqlbase.GetMasterGTID(db)
+		got, err := mysqlbase.GetMasterGTID(db, 5000)
 		assert.Nil(t, err)
 		assert.Equal(t, want, *got)
 	}

--- a/src/mysql/rpc_mysql.go
+++ b/src/mysql/rpc_mysql.go
@@ -97,7 +97,7 @@ func (m *MysqlRPC) Status(req *model.MysqlStatusRPCRequest, rsp *model.MysqlStat
 	var err error
 
 	rsp.RetCode = model.OK
-	if rsp.GTID, err = m.mysql.GetGTID(); err != nil {
+	if rsp.GTID, err = m.mysql.GetGTID(0); err != nil {
 		rsp.RetCode = err.Error()
 		return nil
 	}

--- a/src/mysqld/mysqld_test.go
+++ b/src/mysqld/mysqld_test.go
@@ -74,7 +74,8 @@ func TestMonitor(t *testing.T) {
 	conf := config.DefaultBackupConfig()
 	// 100ms
 	conf.MysqldMonitorInterval = 100
-	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
+	conf.DefaultsFile = "/etc/my.cnf"
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	mysqld := NewMysqld(conf, log)
 
 	{

--- a/src/raft/attr.go
+++ b/src/raft/attr.go
@@ -155,7 +155,7 @@ func (r *Raft) getEpochID() uint64 {
 }
 
 func (r *Raft) getGTID() (model.GTID, error) {
-	return r.mysql.GetGTID()
+	return r.mysql.GetGTID(0)
 }
 
 func (r *Raft) getLeader() string {

--- a/src/raft/candidate.go
+++ b/src/raft/candidate.go
@@ -203,7 +203,7 @@ func (r *Candidate) processRequestVoteRequest(req *model.RaftRPCRequest) *model.
 
 	// 2. check GTID
 	{
-		greater, thisGTID, err := r.mysql.GTIDGreaterThan(&req.GTID)
+		greater, thisGTID, err := r.mysql.GTIDGreaterThan(&req.GTID, nil)
 		if err != nil {
 			r.ERROR("process.requestvote.get.gtid.error[%v].ret.ErrorMySQLDown", err)
 			rsp.RetCode = model.ErrorMySQLDown

--- a/src/raft/follower.go
+++ b/src/raft/follower.go
@@ -153,7 +153,7 @@ func (r *Follower) processHeartbeatRequest(req *model.RaftRPCRequest) *model.Raf
 
 		// MySQL4: change master
 		if r.getLeader() != req.GetFrom() {
-			gtid, err := r.mysql.GetGTID()
+			gtid, err := r.mysql.GetGTID(0)
 			if err == nil {
 				r.WARNING("get.heartbeat.my.gtid.is:%v", gtid)
 			}
@@ -235,7 +235,7 @@ func (r *Follower) processRequestVoteRequest(req *model.RaftRPCRequest) *model.R
 			r.ERROR("mysql.StopSlaveIOThread.error[%+v]", err)
 		}
 
-		greater, thisGTID, err := r.mysql.GTIDGreaterThan(&req.GTID)
+		greater, thisGTID, err := r.mysql.GTIDGreaterThan(&req.GTID, nil)
 		if err != nil {
 			r.ERROR("process.requestvote.get.gtid.error[%v].ret.ErrorMySQLDown", err)
 			rsp.RetCode = model.ErrorMySQLDown
@@ -406,7 +406,7 @@ func (r *Follower) setMySQLAsync() {
 		r.WARNING("prepareAsync.done")
 
 		// Log the gtid info.
-		if gtid, err := r.mysql.GetGTID(); err != nil {
+		if gtid, err := r.mysql.GetGTID(0); err != nil {
 			r.ERROR("init.get.mysql.gtid.error:%v", err)
 		} else {
 			r.WARNING("init.my.gtid.is:%v", gtid)

--- a/src/raft/mock.go
+++ b/src/raft/mock.go
@@ -207,7 +207,7 @@ func (r *Raft) mockLeaderProcessHeartbeatRequest(req *model.RaftRPCRequest) *mod
 
 // mock leader process requestvote request from other candidate
 // nop here, so our leader state won't be changed(degrade)
-func (r *Raft) mockLeaderProcessRequestVoteRequest(req *model.RaftRPCRequest) *model.RaftRPCResponse {
+func (r *Raft) mockLeaderProcessRequestVoteRequest(raftReqVoteCnt *int, req *model.RaftRPCRequest) *model.RaftRPCResponse {
 	rsp := model.NewRaftRPCResponse(model.ErrorInvalidRequest)
 	rsp.Raft.From = r.getID()
 	rsp.Raft.ViewID = r.getViewID()

--- a/src/raft/peer.go
+++ b/src/raft/peer.go
@@ -47,7 +47,7 @@ func (p *Peer) sendHeartbeat(c chan *model.RaftRPCResponse) {
 	req.Peers = p.raft.getPeers()
 	req.IdlePeers = p.raft.getIdlePeers()
 	req.Repl = p.raft.mysql.GetRepl()
-	req.GTID, _ = p.raft.mysql.GetGTID()
+	req.GTID, _ = p.raft.mysql.GetGTID(0)
 
 	client, cleanup, err := p.NewClient()
 	if err != nil {

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -88,7 +88,7 @@ func (s *Server) setupMysql() {
 		return
 	}
 
-	gtid, _ := s.mysql.GetGTID()
+	gtid, _ := s.mysql.GetGTID(0)
 	log.Info("server.mysql.gtid:%+v", gtid)
 
 	log.Info("server.mysql.set.to.READONLY")


### PR DESCRIPTION
When mysqld is under high pressure, the value of timeout that the leader execute GetGTID each time should be different.

The value of timeout needs to increase as the number of raft vote count. This case has no effect on the leader when the pressure is normal.

If raft role is follower or candidate, it's no need to change the timeout.