### PR TITLE
propose: increase mysql cli timeout(#90)

### DIFF
--- a/src/mysql/mysqlbase.go
+++ b/src/mysql/mysqlbase.go
@@ -43,8 +43,8 @@ var (
 	}
 
 	_ MysqlHandler = &MysqlBase{}
-	// timeout is 5s
-	reqTimeout = 1000 * 5
+	// timeout is 10s
+	reqTimeout = 10000
 )
 
 // MysqlBase tuple.

--- a/src/mysqld/mysqld_test.go
+++ b/src/mysqld/mysqld_test.go
@@ -74,7 +74,8 @@ func TestMonitor(t *testing.T) {
 	conf := config.DefaultBackupConfig()
 	// 100ms
 	conf.MysqldMonitorInterval = 100
-	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
+	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
+	conf.DefaultsFile = "/etc/my.cnf"
 	mysqld := NewMysqld(conf, log)
 
 	{


### PR DESCRIPTION
Reduce timeout errors caused by MySQL not being able to respond immediately when under high pressure