### PR TITLE
raft: optimize high availability logic

### DIFF
--- a/src/mysql/api_test.go
+++ b/src/mysql/api_test.go
@@ -28,7 +28,7 @@ func TestSetReadOnly(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	queryList := []string{
@@ -56,7 +56,7 @@ func TestStartSlaveIOThread(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "START SLAVE IO_THREAD"
@@ -73,7 +73,7 @@ func TestStopSlaveIOThread(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "STOP SLAVE IO_THREAD"
@@ -90,7 +90,7 @@ func TestStartSlave(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "START SLAVE"
@@ -107,7 +107,7 @@ func TestStopSlave(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "STOP SLAVE"
@@ -124,7 +124,7 @@ func TestChangeMasterTo(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	queryList := []string{"STOP SLAVE",
@@ -148,7 +148,7 @@ func TestChangeToMaster(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	queryList := []string{"STOP SLAVE",
@@ -169,7 +169,7 @@ func TestWaitUntilAfterGTID(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "SELECT WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS('1')"
@@ -186,7 +186,7 @@ func TestGetLocalGTID(t *testing.T) {
 	//log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "SELECT @@SERVER_UUID"
@@ -208,7 +208,7 @@ func TestCheckGTID(t *testing.T) {
 	//log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	// local is a normal follower, leader Executed_GTID_Set is ""
@@ -368,7 +368,7 @@ func TestGTIDGreaterThan(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	// 1. show slave status OK
@@ -513,7 +513,7 @@ func TestGetGTID(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	// 1. show slave status OK
@@ -634,7 +634,7 @@ func TestPromotableYes(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	// 2. mock Slave_SQL_Running OK
@@ -684,7 +684,7 @@ func TestPromotableNot(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	// 1. mock MysqlDead
@@ -791,7 +791,7 @@ func TestWaitMysqlWorks(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 	mysql.PingStart()
 	defer mysql.PingStop()
@@ -799,7 +799,7 @@ func TestWaitMysqlWorks(t *testing.T) {
 	// works
 	{
 		conf := config.DefaultMysqlConfig()
-		mysql := NewMysql(conf, log)
+		mysql := NewMysql(conf, 10000, log)
 		mysql.db = db
 
 		query := "SHOW SLAVE STATUS"
@@ -823,7 +823,7 @@ func TestWaitMysqlWorks(t *testing.T) {
 	// timeouts
 	{
 		conf := config.DefaultMysqlConfig()
-		mysql := NewMysql(conf, log)
+		mysql := NewMysql(conf, 10000, log)
 		mysql.db = db
 		mysql.PingStart()
 		defer mysql.PingStop()
@@ -846,7 +846,7 @@ func TestGlobalSysVar(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	queryList := []string{
@@ -877,13 +877,13 @@ func TestSemiSyncMaster(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	queryList := []string{
 		"SET GLOBAL rpl_semi_sync_master_enabled=ON",
 		"SET GLOBAL rpl_semi_sync_master_enabled=OFF",
-		"SET GLOBAL rpl_semi_sync_master_timeout=300000",
+		"SET GLOBAL rpl_semi_sync_master_timeout=10000",
 	}
 
 	mock.ExpectExec(queryList[0]).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -895,7 +895,7 @@ func TestSemiSyncMaster(t *testing.T) {
 	assert.Nil(t, err)
 
 	mock.ExpectExec(queryList[2]).WillReturnResult(sqlmock.NewResult(1, 1))
-	err = mysql.SetSemiSyncMasterTimeout(300000)
+	err = mysql.SetSemiSyncMasterTimeout(10000)
 	assert.Nil(t, err)
 }
 
@@ -907,7 +907,7 @@ func TestPurgeBinlogsTo(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	// 1. show slave status OK
@@ -926,7 +926,7 @@ func TestSetMasterSysVars(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.ERROR))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 	err = mysql.SetMasterGlobalSysVar()
 	assert.Nil(t, err)
@@ -960,7 +960,7 @@ func TestSetSlaveSysVars(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.ERROR))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	err = mysql.SetSlaveGlobalSysVar()

--- a/src/mysql/mock.go
+++ b/src/mysql/mock.go
@@ -23,6 +23,7 @@ import (
 
 // MockGTID tuple.
 type MockGTID struct {
+	SetQueryTimeoutFn          func(int)
 	PingFn                     func(*sql.DB) (*PingEntry, error)
 	SetReadOnlyFn              func(*sql.DB, bool) error
 	GetMasterGTIDFn            func(*sql.DB) (*model.GTID, error)
@@ -174,6 +175,15 @@ func DefaultCheckGTID(followerGTID *model.GTID, leaderGTID *model.GTID) bool {
 // GetGtidSubtract mock.
 func (mogtid *MockGTID) GetGtidSubtract(db *sql.DB, slaveGTID string, masterGTID string) (string, error) {
 	return mogtid.GetGtidSubtractFn(db, slaveGTID, masterGTID)
+}
+
+// DefaultSetQueryTimeout mock.
+func DefaultSetQueryTimeout(timeout int) {
+}
+
+// SetQueryTimeout mock.
+func (mogtid *MockGTID) SetQueryTimeout(timeout int) {
+	mogtid.SetQueryTimeoutFn(timeout)
 }
 
 // DefaultPing mock.
@@ -387,6 +397,7 @@ func (mogtid *MockGTID) GrantAllPrivileges(db *sql.DB, user string, host, passwd
 
 func defaultMockGTID() *MockGTID {
 	mock := &MockGTID{}
+	mock.SetQueryTimeoutFn = DefaultSetQueryTimeout
 	mock.PingFn = DefaultPing
 	mock.SetReadOnlyFn = DefaultSetReadOnly
 	mock.GetMasterGTIDFn = DefaultGetMasterGTID
@@ -948,7 +959,7 @@ func NewMockGTIDX5ChangeToMasterError() *MockGTID {
 func MockMysql(log *xlog.Log, port int, h MysqlHandler) (string, *Mysql, func()) {
 	id := fmt.Sprintf("127.0.0.1:%d", port)
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 
 	// setup rpc
 	rpc, err := xrpc.NewService(xrpc.Log(log),
@@ -974,7 +985,7 @@ func MockMysql(log *xlog.Log, port int, h MysqlHandler) (string, *Mysql, func())
 func MockMysqlReplUser(log *xlog.Log, port int, h MysqlHandler) (string, *Mysql, func()) {
 	id := fmt.Sprintf("127.0.0.1:%d", port)
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 
 	// setup rpc
 	rpc, err := xrpc.NewService(xrpc.Log(log),

--- a/src/mysql/mysql.go
+++ b/src/mysql/mysql.go
@@ -61,8 +61,8 @@ type Mysql struct {
 }
 
 // NewMysql creates the new Mysql.
-func NewMysql(conf *config.MysqlConfig, log *xlog.Log) *Mysql {
-	return &Mysql{
+func NewMysql(conf *config.MysqlConfig, queryTimeout int, log *xlog.Log) *Mysql {
+	mysql := &Mysql{
 		db:           nil,
 		log:          log,
 		conf:         conf,
@@ -70,6 +70,8 @@ func NewMysql(conf *config.MysqlConfig, log *xlog.Log) *Mysql {
 		mysqlHandler: getHandler(conf.Version),
 		pingTicker:   common.NormalTicker(conf.PingTimeout),
 	}
+	mysql.mysqlHandler.SetQueryTimeout(queryTimeout)
+	return mysql
 }
 
 // SetMysqlHandler used to set the repl handler.

--- a/src/mysql/mysql56_test.go
+++ b/src/mysql/mysql56_test.go
@@ -24,8 +24,9 @@ func TestMysql56Handler(t *testing.T) {
 	conf := config.DefaultMysqlConfig()
 	conf.Version = "mysql56"
 
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	want := new(Mysql56)
+	want.SetQueryTimeout(10000)
 	got := mysql.mysqlHandler
 	assert.Equal(t, want, got)
 }
@@ -39,7 +40,7 @@ func TestMysql56SetSemiWaitSlaveCount(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
 	conf.Version = "mysql56"
-	mysql56 := NewMysql(conf, log)
+	mysql56 := NewMysql(conf, 10000, log)
 	mysql56.db = db
 
 	queryList := []string{
@@ -60,7 +61,7 @@ func TestMysql56ChangeUserPassword(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
 	conf.Version = "mysql56"
-	mysql56 := NewMysql(conf, log)
+	mysql56 := NewMysql(conf, 10000, log)
 	mysql56.db = db
 
 	queryList := []string{
@@ -81,7 +82,7 @@ func TestMysql56CreateUser(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
 	conf.Version = "mysql56"
-	mysql56 := NewMysql(conf, log)
+	mysql56 := NewMysql(conf, 10000, log)
 	mysql56.db = db
 
 	// ssl is NO
@@ -106,7 +107,7 @@ func TestMysql56CreateUserWithPrivileges(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
 	conf.Version = "mysql56"
-	mysql56 := NewMysql(conf, log)
+	mysql56 := NewMysql(conf, 10000, log)
 	mysql56.db = db
 
 	queryList := []string{
@@ -137,7 +138,7 @@ func TestMysql56GrantAllPrivileges(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
 	conf.Version = "mysql56"
-	mysql56 := NewMysql(conf, log)
+	mysql56 := NewMysql(conf, 10000, log)
 	mysql56.db = db
 
 	queryList := []string{

--- a/src/mysql/mysql57_test.go
+++ b/src/mysql/mysql57_test.go
@@ -22,8 +22,9 @@ func TestMysql57Handler(t *testing.T) {
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
 
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	want := new(Mysql57)
+	want.SetQueryTimeout(10000)
 	got := mysql.mysqlHandler
 	assert.Equal(t, want, got)
 }

--- a/src/mysql/mysql80_test.go
+++ b/src/mysql/mysql80_test.go
@@ -23,8 +23,9 @@ func TestMysql80Handler(t *testing.T) {
 	conf := config.DefaultMysqlConfig()
 	conf.Version = "mysql80"
 
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	want := new(Mysql80)
+	want.SetQueryTimeout(10000)
 	got := mysql.mysqlHandler
 	assert.Equal(t, want, got)
 }

--- a/src/mysql/mysql_handler.go
+++ b/src/mysql/mysql_handler.go
@@ -15,6 +15,8 @@ import (
 
 // MysqlHandler interface.
 type MysqlHandler interface {
+	SetQueryTimeout(int)
+
 	// check health and return log_bin_basename
 	Ping(*sql.DB) (*PingEntry, error)
 

--- a/src/mysql/mysql_test.go
+++ b/src/mysql/mysql_test.go
@@ -73,7 +73,7 @@ func TestMysqlGTIDGreatThan(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 
 	// Set mock functions
 	mysql.SetMysqlHandler(new(MockGTIDB))

--- a/src/mysql/mysqlbase_test.go
+++ b/src/mysql/mysqlbase_test.go
@@ -26,6 +26,7 @@ var mysqlbase = new(MysqlBase)
 func TestMysqlBasePing(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	query := "SHOW SLAVE STATUS"
@@ -50,6 +51,7 @@ func TestMysqlBasePing(t *testing.T) {
 func TestMysqlBaseGetSlaveGTIDGotZeroRow(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	query := "SHOW SLAVE STATUS"
@@ -75,6 +77,7 @@ func TestMysqlBaseGetSlaveGTIDGotZeroRow(t *testing.T) {
 func TestMysqlBaseGetSlaveGTID(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	query := "SHOW SLAVE STATUS"
@@ -124,6 +127,7 @@ func TestMysqlBaseGetMasterGTID(t *testing.T) {
 	{
 		db, mock, err := sqlmock.New()
 		assert.Nil(t, err)
+		mysqlbase.SetQueryTimeout(10000)
 		defer db.Close()
 
 		query := "SHOW MASTER STATUS"
@@ -162,6 +166,7 @@ func TestMysqlBaseGetMasterGTID(t *testing.T) {
 func TestGetUUID(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	query := "SELECT @@SERVER_UUID"
@@ -178,6 +183,7 @@ func TestGetUUID(t *testing.T) {
 func TestMysqlBaseChangeMasterToCommand(t *testing.T) {
 	db, _, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	want := []string{
@@ -200,6 +206,7 @@ func TestMysqlBaseChangeMasterToCommand(t *testing.T) {
 func TestMysqlBaseChangeMasterTo(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	queryList := []string{"STOP SLAVE",
@@ -222,6 +229,7 @@ func TestMysqlBaseChangeMasterTo(t *testing.T) {
 func TestMysqlBaseChangeToMaster(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	queryList := []string{"STOP SLAVE",
@@ -237,6 +245,7 @@ func TestMysqlBaseChangeToMaster(t *testing.T) {
 func TestMysqlBaseSlaveIOThread(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	queryList := []string{
@@ -256,6 +265,7 @@ func TestMysqlBaseSlaveIOThread(t *testing.T) {
 func TestMysqlBaseReadOnly(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	queryList := []string{
@@ -279,6 +289,7 @@ func TestMysqlBaseReadOnly(t *testing.T) {
 func TestMysqlBaseSetGlobalVar(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	queryList := []string{
@@ -304,6 +315,7 @@ func TestMysqlBaseSetGlobalVar(t *testing.T) {
 func TestMysqlBaseResetMaster(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	queryList := []string{
@@ -318,6 +330,7 @@ func TestMysqlBaseResetMaster(t *testing.T) {
 func TestMysqlBasePurgeBinlogsTo(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	queryList := []string{
@@ -332,6 +345,7 @@ func TestMysqlBasePurgeBinlogsTo(t *testing.T) {
 func TestMysqlBaseSemiMaster(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	queryList := []string{
@@ -351,14 +365,15 @@ func TestMysqlBaseSemiMaster(t *testing.T) {
 func TestMysqlBaseSemiMasterTimeout(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.Nil(t, err)
+	mysqlbase.SetQueryTimeout(10000)
 	defer db.Close()
 
 	queryList := []string{
-		"SET GLOBAL rpl_semi_sync_master_timeout=300000",
+		"SET GLOBAL rpl_semi_sync_master_timeout=10000",
 	}
 
 	mock.ExpectExec(queryList[0]).WillReturnResult(sqlmock.NewResult(1, 1))
-	err = mysqlbase.SetSemiSyncMasterTimeout(db, 300000)
+	err = mysqlbase.SetSemiSyncMasterTimeout(db, 10000)
 	assert.Nil(t, err)
 }
 
@@ -370,7 +385,7 @@ func TestCheckUserExists(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "SELECT User FROM mysql.user WHERE User = 'xx' and Host = '192.168.0.%'"
@@ -394,7 +409,7 @@ func TestCreateUser(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	// ssl is NO
@@ -418,7 +433,7 @@ func TestCreateUserWithPrivileges(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	queryList := []string{
@@ -448,7 +463,7 @@ func TestGetUser(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "SELECT User, Host, Super_priv FROM mysql.user"
@@ -479,7 +494,7 @@ func TestDropUser(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "DROP USER `xx`@`127.0.0.1`"
@@ -496,7 +511,7 @@ func TestCreateReplUserWithoutBinlog(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	queryList := []string{
@@ -522,7 +537,7 @@ func TestCreateReplUserWithoutBinlogErr(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	queryList := []string{
@@ -550,7 +565,7 @@ func TestChangeUserPasswd(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "ALTER USER `xx`@`localhost` IDENTIFIED BY 'xxx'"
@@ -567,7 +582,7 @@ func TestGrantAllPrivileges(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	queryList := []string{
@@ -597,7 +612,7 @@ func TestGrantNormalPrivileges(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "GRANT ALTER,ALTER ROUTINE,CREATE,CREATE ROUTINE,CREATE TEMPORARY TABLES,CREATE VIEW,DELETE,DROP,EXECUTE,EVENT,INDEX,INSERT,LOCK TABLES,PROCESS,RELOAD,SELECT,SHOW DATABASES,SHOW VIEW,UPDATE,TRIGGER,REFERENCES,REPLICATION SLAVE,REPLICATION CLIENT ON *.* TO `xx`@`127.0.0.1`"
@@ -614,7 +629,7 @@ func TestGrantReplicationPrivileges(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	query := "GRANT REPLICATION SLAVE,REPLICATION CLIENT ON *.* TO `xx`"
@@ -631,7 +646,7 @@ func TestGrantUserPrivileges(t *testing.T) {
 	// log
 	log := xlog.NewStdLog(xlog.Level(xlog.DEBUG))
 	conf := config.DefaultMysqlConfig()
-	mysql := NewMysql(conf, log)
+	mysql := NewMysql(conf, 10000, log)
 	mysql.db = db
 
 	user := "xx"

--- a/src/raft/attr.go
+++ b/src/raft/attr.go
@@ -16,9 +16,8 @@ import (
 )
 
 const (
-	noVote      = ""
-	noLeader    = ""
-	maxSendTime = 1000 // max send timeout 1sec
+	noVote   = ""
+	noLeader = ""
 )
 
 // State enum.
@@ -154,8 +153,8 @@ func (r *Raft) getEpochID() uint64 {
 	return atomic.LoadUint64(&r.meta.EpochID)
 }
 
-func (r *Raft) getGTID() (model.GTID, error) {
-	return r.mysql.GetGTID()
+func (r *Raft) getGTID() model.GTID {
+	return r.gtid
 }
 
 func (r *Raft) getLeader() string {

--- a/src/raft/idle.go
+++ b/src/raft/idle.go
@@ -189,8 +189,10 @@ func (r *Idle) stateInit() {
 
 func (r *Idle) processPingRequest(req *model.RaftRPCRequest) *model.RaftRPCResponse {
 	rsp := model.NewRaftRPCResponse(model.OK)
+	rsp.Raft.From = r.getID()
+	rsp.Raft.ViewID = r.getViewID()
+	rsp.Raft.EpochID = r.getEpochID()
 	rsp.Raft.State = r.state.String()
-
 	return rsp
 }
 

--- a/src/raft/invalid.go
+++ b/src/raft/invalid.go
@@ -183,8 +183,10 @@ func (r *Invalid) stateInit() {
 
 func (r *Invalid) processPingRequest(req *model.RaftRPCRequest) *model.RaftRPCResponse {
 	rsp := model.NewRaftRPCResponse(model.OK)
+	rsp.Raft.From = r.getID()
+	rsp.Raft.ViewID = r.getViewID()
+	rsp.Raft.EpochID = r.getEpochID()
 	rsp.Raft.State = r.state.String()
-
 	return rsp
 }
 

--- a/src/raft/learner.go
+++ b/src/raft/learner.go
@@ -154,6 +154,9 @@ func (r *Learner) processRequestVoteRequest(req *model.RaftRPCRequest) *model.Ra
 
 func (r *Learner) processPingRequest(req *model.RaftRPCRequest) *model.RaftRPCResponse {
 	rsp := model.NewRaftRPCResponse(model.OK)
+	rsp.Raft.From = r.getID()
+	rsp.Raft.ViewID = r.getViewID()
+	rsp.Raft.EpochID = r.getEpochID()
 	rsp.Raft.State = r.state.String()
 	return rsp
 }

--- a/src/raft/mock.go
+++ b/src/raft/mock.go
@@ -83,7 +83,7 @@ func mockRafts(log *xlog.Log, conf *config.RaftConfig, port int, count int, idle
 		}
 
 		// setup mysql
-		mysql57 := mysql.NewMysql(config.DefaultMysqlConfig(), log)
+		mysql57 := mysql.NewMysql(config.DefaultMysqlConfig(), 10000, log)
 		mysql57.SetMysqlHandler(mysql.NewMockGTIDA())
 		mysql57.PingStart()
 

--- a/src/raft/raft.go
+++ b/src/raft/raft.go
@@ -75,6 +75,7 @@ type Raft struct {
 	skipPurgeBinlog     bool // if true, purge binlog will skipped
 	skipCheckSemiSync   bool // if true, check semi-sync will skipped
 	isBrainSplit        bool // if true, follower can upgrade to candidate
+	gtid                model.GTID
 }
 
 // NewRaft creates the new raft.
@@ -213,7 +214,7 @@ func (r *Raft) freePeers() {
 
 // send command to state machine(F/C/L/I/S) loop with maxSendTime tiemout
 // (F/C/L/I/S)-loop should handle it and return
-func (r *Raft) send(t int, request interface{}) (interface{}, error) {
+func (r *Raft) send(t int, request interface{}, maxSendTime int) (interface{}, error) {
 	if !r.running() {
 		return nil, errStop
 	}

--- a/src/raft/rpc_raft.go
+++ b/src/raft/rpc_raft.go
@@ -21,7 +21,7 @@ type RaftRPC struct {
 // Ping rpc.
 // send MsgRaftPing
 func (r *RaftRPC) Ping(req *model.RaftRPCRequest, rsp *model.RaftRPCResponse) error {
-	ret, err := r.raft.send(MsgRaftPing, req)
+	ret, err := r.raft.send(MsgRaftPing, req, r.raft.getHeartbeatTimeout())
 	if err != nil {
 		return err
 	}
@@ -31,7 +31,7 @@ func (r *RaftRPC) Ping(req *model.RaftRPCRequest, rsp *model.RaftRPCResponse) er
 
 // Heartbeat rpc.
 func (r *RaftRPC) Heartbeat(req *model.RaftRPCRequest, rsp *model.RaftRPCResponse) error {
-	ret, err := r.raft.send(MsgRaftHeartbeat, req)
+	ret, err := r.raft.send(MsgRaftHeartbeat, req, r.raft.getHeartbeatTimeout())
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func (r *RaftRPC) Heartbeat(req *model.RaftRPCRequest, rsp *model.RaftRPCRespons
 
 // RequestVote rpc.
 func (r *RaftRPC) RequestVote(req *model.RaftRPCRequest, rsp *model.RaftRPCResponse) error {
-	ret, err := r.raft.send(MsgRaftRequestVote, req)
+	ret, err := r.raft.send(MsgRaftRequestVote, req, r.raft.getHeartbeatTimeout())
 	if err != nil {
 		return err
 	}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -51,7 +51,7 @@ func NewServer(conf *config.Config, log *xlog.Log) *Server {
 	}
 
 	s.mysqld = mysqld.NewMysqld(conf.Backup, log)
-	s.mysql = mysql.NewMysql(conf.Mysql, log)
+	s.mysql = mysql.NewMysql(conf.Mysql, conf.Raft.ElectionTimeout, log)
 	s.raft = raft.NewRaft(conf.Server.Endpoint, conf.Raft, log, s.mysql)
 	rpc, err := xrpc.NewService(xrpc.Log(log),
 		xrpc.ConnectionStr(conf.Server.Endpoint))

--- a/src/xbase/common/common.go
+++ b/src/xbase/common/common.go
@@ -14,7 +14,14 @@ import (
 )
 
 func RandomTimeout(min int) *time.Timer {
-	max := min * 2
+	var max int
+	if min <= 5 {
+		max = min * 2
+	} else if min <= 20 {
+		max = min + min/2
+	} else {
+		max = min + 10
+	}
 	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
 	d, delta := min, (max - min)
 	if delta > 0 {


### PR DESCRIPTION
1. mysql: associate query timeout with election-timeout
2. raft: associate rpc timeout with election-timeout
3. raft: the GTID needed for the heartbeat is called on a separate thread
4. raft: fix a bug that candidates can vote repeatedly for the same term