### PR TITLE
server: add -r option on startup to specify the initial role

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Xenon has many cool features, such as:
 - [build and run xenon](docs/how_to_build_and_run_xenon.md) : How to build and run xenon.
 - [xenon cli commands](docs/xenoncli_commands.md) : Xenon client commands.
 - [how xenon works](docs/how_xenon_works.md) : How xenon works.
+- [how xenon upgrades](docs/how_xenon_upgrades.md): How xenon upgrades.
 
 ## Use case
 

--- a/docs/how_xenon_upgrades.md
+++ b/docs/how_xenon_upgrades.md
@@ -1,0 +1,133 @@
+Table of Contents
+=================
+
+* [How to upgrade xenon without affecting MySQL service](#how-to-upgrade-xenon-without-affecting-mysql-service)
+    * [Cluster information](#cluster-information)
+    * [Step1. Stop the xenon process for all nodes](#step1-stop-the-xenon-process-for-all-nodes)
+    * [Step2. Remove peers.json for all nodes](#step2-remove-peersjson-for-all-nodes)
+    * [Step3. Upgrade xenon](#step3-upgrade-xenon)
+    * [Step4. Start xenon on xenon-1](#step4-start-xenon-on-xenon-1)
+    * [Step5. Start xenon on xenon-2](#step5-start-xenon-on-xenon-2)
+    * [Step6. Add peers for xenon-1](#step6-add-peers-for-xenon-1)
+    * [Step7. Add peers for xenon-2](#step7-add-peers-for-xenon-2)
+    * [Step8. Start xenon on xenon-3](#step8-start-xenon-on-xenon-3)
+    * [Step9. Add peers for xenon-1 and xenon-2](#step9-add-peers-for-xenon-1-and-xenon-2)
+    * [Step10. Add peers for xenon-3](#step10-add-peers-for-xenon-3)
+    * [Step11. Check cluster status](#step11-check-cluster-status)
+
+
+# How to upgrade xenon without affecting MySQL service
+
+## Cluster information
+
+Assume:
+
+1. Cluster has 3 nodes :
+```
+xenon-1: 192.168.0.2:8801 LEADER
+xenon-2: 192.168.0.3:8801 FOLLOWER
+xenon-3: 192.168.0.4:8801 FOLLOWER
+```
+
+2. The relevant paths:
+```bash
+# The directory of the xenon binary
+export XENON_BIN=/opt/xenon
+# The path of the config file
+export XENON_CONF=/etc/xenon/xenon.json
+# The path of the peers file
+export XENON_PEERS=/data/raft/peers.json
+# The path of the log file
+export XENON_LOG=/data/log/xenon.log
+```
+
+## Step1. Stop the xenon process for all nodes
+
+Executing follow command on `xenon-1`:
+```bash
+# avoid leader degrade and remove vip during command execution
+pkill -9 xenon && ssh 192.168.0.3 "pkill -9 xenon" && ssh 192.168.0.4 "pkill -9 xenon"
+```
+
+## Step2. Remove peers.json for all nodes
+
+Executing follow command on all nodes:
+```bash
+rm ${XENON_PEERS} -f
+```
+
+## Step3. Upgrade xenon
+
+Replace the latest `xenon` and `xenoncli` for all nodes.
+
+## Step4. Start xenon on xenon-1
+
+Executing follow command on `xenon-1`:
+```bash
+# 
+${XENON_BIN}/xenon -c ${XENON_CONF} -r LEADER >> ${XENON_LOG} 2>&1 &
+```
+
+## Step5. Start xenon on xenon-2
+
+Executing follow command on `xenon-2`:
+```bash
+${XENON_BIN}/xenon -c ${XENON_CONF} >> ${XENON_LOG} 2>&1 &
+```
+
+## Step6. Add peers for xenon-1
+
+Executing follow command on `xenon-1`:
+```bash
+${XENON_BIN}/xenoncli cluster add 192.168.0.3:8801
+```
+
+## Step7. Add peers for xenon-2
+
+Executing follow command on `xenon-2`:
+```bash
+${XENON_BIN}/xenoncli cluster add 192.168.0.2:8801
+```
+
+## Step8. Start xenon on xenon-3
+
+Executing follow command on `xenon-3`:
+```bash
+${XENON_BIN}/xenon -c ${XENON_CONF} >> ${XENON_LOG} 2>&1 &
+```
+
+## Step9. Add peers for xenon-1 and xenon-2
+
+Executing follow command on `xenon-1`(LEADER):
+```bash
+${XENON_BIN}/xenoncli cluster add 192.168.0.4:8801
+```
+
+## Step10. Add peers for xenon-3
+
+Executing follow command on `xenon-3`:
+```bash
+${XENON_BIN}/xenoncli cluster add 192.168.0.2:8801,192.168.0.3:8801
+```
+
+## Step11. Check cluster status
+
+```bash
+${XENON_BIN}/xenoncli cluster status
+```
+
+Output:
+```
++-------------------+--------------------------------+---------+---------+--------------------------+---------------------+----------------+------------------+
+|        ID         |              Raft              | Mysqld  | Monitor |          Backup          |        Mysql        | IO/SQL_RUNNING |     MyLeader     |
++-------------------+--------------------------------+---------+---------+--------------------------+---------------------+----------------+------------------+
+| 192.168.0.2:8801  | [ViewID:1  EpochID:2]@LEADER   | RUNNING | ON      | state:[NONE]␤            | [ALIVE] [READWRITE] | [true/true]    | 192.168.0.2:8801 |
+|                   |                                |         |         | LastError:               |                     |                |                  |
++-------------------+--------------------------------+---------+---------+--------------------------+---------------------+----------------+------------------+
+| 192.168.0.3:8801  | [ViewID:1  EpochID:2]@FOLLOWER | RUNNING | ON      | state:[NONE]␤            | [ALIVE] [READONLY]  | [true/true]    | 192.168.0.2:8801 |
+|                   |                                |         |         | LastError:               |                     |                |                  |
++-------------------+--------------------------------+---------+---------+--------------------------+---------------------+----------------+------------------+
+| 192.168.0.4:8801  | [ViewID:1  EpochID:2]@FOLLOWER | RUNNING | ON      | state:[NONE]␤            | [ALIVE] [READONLY]  | [true/true]    | 192.168.0.2:8801 |
+|                   |                                |         |         | LastError:               |                     |                |                  |
++-------------------+--------------------------------+---------+---------+--------------------------+---------------------+----------------+------------------+
+```

--- a/src/mysql/api.go
+++ b/src/mysql/api.go
@@ -261,6 +261,11 @@ func (m *Mysql) GetState() model.MysqlState {
 	return m.getState()
 }
 
+// SetState set the mysql state.
+func (m *Mysql) SetState(state model.MysqlState) {
+	m.setState(state)
+}
+
 // GetOption returns the mysql option.
 func (m *Mysql) GetOption() Option {
 	return m.getOption()

--- a/src/raft/attr.go
+++ b/src/raft/attr.go
@@ -46,6 +46,9 @@ const (
 
 	// STOPPED state.
 	STOPPED
+
+	// UNKNOW state.
+	UNKNOW
 )
 
 func (s State) String() string {

--- a/src/raft/leader.go
+++ b/src/raft/leader.go
@@ -427,7 +427,12 @@ func (r *Leader) prepareSettingsAsync() {
 		}
 		r.WARNING("mysql.SetReadWrite.done")
 		r.WARNING("6. start.vip.prepare")
-		if err := r.leaderStartShellCommand(); err != nil {
+		if r.initRole == LEADER {
+			// The -r LEADER is specified at startup server, ndicates that the current node
+			// has previously executed leaderStartShellCommand，skip this one.
+			r.initRole = UNKNOW
+			r.WARNING("the.init.role.is.leader.skip")
+		} else if err := r.leaderStartShellCommand(); err != nil {
 			// TODO(array): what todo?
 			r.ERROR("leader.StartShellCommand.error[%v]", err)
 		}

--- a/src/raft/mock.go
+++ b/src/raft/mock.go
@@ -65,6 +65,7 @@ func MockRaftsWithLong(log *xlog.Log, port int, count int, idleStart int) ([]str
 
 func mockRafts(log *xlog.Log, conf *config.RaftConfig, port int, count int, idleStart int, islong bool) ([]string, []*Raft, func()) {
 	ids := []string{}
+	var raft *Raft
 	rafts := []*Raft{}
 	rpcs := []*xrpc.Service{}
 	ip, _ := common.GetLocalIP()
@@ -87,8 +88,15 @@ func mockRafts(log *xlog.Log, conf *config.RaftConfig, port int, count int, idle
 		mysql57.SetMysqlHandler(mysql.NewMockGTIDA())
 		mysql57.PingStart()
 
+		for i, id := range ids {
+			if idleStart != -1 && i >= idleStart {
+				raft = NewRaft(id, conf, log, mysql57, IDLE)
+			} else {
+				raft = NewRaft(id, conf, log, mysql57, FOLLOWER)
+			}
+		}
+
 		// setup raft
-		raft := NewRaft(id, conf, log, mysql57)
 		rafts = append(rafts, raft)
 
 		// setup rpc

--- a/src/raft/rpc_ha_test.go
+++ b/src/raft/rpc_ha_test.go
@@ -775,7 +775,7 @@ func TestRaftSuperIDLEEnableHA(t *testing.T) {
 
 	log := xlog.NewStdLog(xlog.Level(xlog.PANIC))
 	port := common.RandomPort(8000, 9000)
-	names, rafts, cleanup := MockRafts(log, port, 3, -1)
+	names, rafts, cleanup := MockRafts(log, port, 3, 2)
 	defer cleanup()
 
 	// 1.  Start 3 rafts.

--- a/src/server/mock.go
+++ b/src/server/mock.go
@@ -42,7 +42,7 @@ func MockServers(log *xlog.Log, port int, count int) ([]*Server, func()) {
 		conf.Raft.HeartbeatTimeout = shortHeartbeatTimeoutForTest
 		conf.Raft.ElectionTimeout = shortHeartbeatTimeoutForTest * 3
 
-		server := NewServer(conf, log)
+		server := NewServer(conf, log, raft.FOLLOWER)
 
 		// mock mysqld
 		_, mysqld, _ := mysqld.MockMysqld(log, port)

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -44,7 +44,7 @@ type Server struct {
 	begin  time.Time
 }
 
-func NewServer(conf *config.Config, log *xlog.Log) *Server {
+func NewServer(conf *config.Config, log *xlog.Log, initState raft.State) *Server {
 	s := &Server{
 		log:  log,
 		conf: conf,
@@ -52,7 +52,7 @@ func NewServer(conf *config.Config, log *xlog.Log) *Server {
 
 	s.mysqld = mysqld.NewMysqld(conf.Backup, log)
 	s.mysql = mysql.NewMysql(conf.Mysql, conf.Raft.ElectionTimeout, log)
-	s.raft = raft.NewRaft(conf.Server.Endpoint, conf.Raft, log, s.mysql)
+	s.raft = raft.NewRaft(conf.Server.Endpoint, conf.Raft, log, s.mysql, initState)
 	rpc, err := xrpc.NewService(xrpc.Log(log),
 		xrpc.ConnectionStr(conf.Server.Endpoint))
 	if err != nil {


### PR DESCRIPTION
We don't want to affect MySQL services when we upgrade xenon, so after the upgrade need to let the old LEADER continue to run as the LEADER and skip leaderStartShellCommand.