### PR TITLE
ctl: Add v1/cluster/gtid api.

### DIFF
--- a/src/ctl/router.go
+++ b/src/ctl/router.go
@@ -23,6 +23,7 @@ func (admin *Admin) NewRouter() (rest.App, error) {
 		// cluster.
 		rest.Post("/v1/cluster/add", v1.ClusterAddHandler(log, xenon)),
 		rest.Post("/v1/cluster/remove", v1.ClusterRemoveHandler(log, xenon)),
+		rest.Get("/v1/cluster/gtid", v1.ClusterGtidHandler(log, xenon)),
 
 		// raft.
 		rest.Get("/v1/raft/status", v1.RaftStatusHandler(log, xenon)),

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -166,13 +166,6 @@ func (s *Server) setupRPC() {
 // start rpc-raft and event&&state-loop
 func (s *Server) Start() {
 	log := s.log
-	defer func() {
-		if r := recover(); r != nil {
-			buf := make([]byte, 4096)
-			buf = buf[:runtime.Stack(buf, false)]
-			log.Error("server.got.panic[%v:%s]", r, buf)
-		}
-	}()
 
 	if !s.conf.Mysql.MonitorDisabled {
 		s.mysqld.MonitorStart()


### PR DESCRIPTION
todo: unit test.

```
$ xenoncli cluster gtid
+------------------------------------------+----------+-------+-----------------------------------------------+----------------------------------------------------+
|                    ID                    |   Raft   | Mysql |               Executed_GTID_Set               |                 Retrieved_GTID_Set                 |
+------------------------------------------+----------+-------+-----------------------------------------------+----------------------------------------------------+
| sample-mysql-0.sample-mysql.default:8801 | FOLLOWER | ALIVE | 996d2005-93aa-11ec-9c92-9a81352e5bf1:1-209213 | 996d2005-93aa-11ec-9c92-9a81352e5bf1:209212-209213 |
+------------------------------------------+----------+-------+-----------------------------------------------+----------------------------------------------------+
| sample-mysql-2.sample-mysql.default:8801 | FOLLOWER | ALIVE | 996d2005-93aa-11ec-9c92-9a81352e5bf1:1-209213 | 996d2005-93aa-11ec-9c92-9a81352e5bf1:209212-209213 |
+------------------------------------------+----------+-------+-----------------------------------------------+----------------------------------------------------+
| sample-mysql-1.sample-mysql.default:8801 | LEADER   | ALIVE | 996d2005-93aa-11ec-9c92-9a81352e5bf1:1-209213 |                    |
+------------------------------------------+----------+-------+-----------------------------------------------+----------------------------------------------------+

$ curl -i -X GET -u root: http://sample-mysql-1.sample-mysql.default:6601/v1/cluster/gtid
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Date: Wed, 23 Feb 2022 10:38:33 GMT
Content-Length: 93

{"executed_gtid_set":"996d2005-93aa-11ec-9c92-9a81352e5bf1:1-209213","retrieved_gtid_set":""}
```